### PR TITLE
src: make module context-aware

### DIFF
--- a/src/zlib_sync.cc
+++ b/src/zlib_sync.cc
@@ -250,4 +250,6 @@ NAN_MODULE_INIT(AllInit) {
     Nan::DefineOwnProperty(target, Nan::New<String>("ZLIB_VERSION").ToLocalChecked(), Nan::New<String>(zlibVersion()).ToLocalChecked(), static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete));
 }
 
-NODE_MODULE(zlib_sync, AllInit)
+NODE_MODULE_INIT() {
+    AllInit(exports);
+}

--- a/src/zlib_sync.cc
+++ b/src/zlib_sync.cc
@@ -250,6 +250,4 @@ NAN_MODULE_INIT(AllInit) {
     Nan::DefineOwnProperty(target, Nan::New<String>("ZLIB_VERSION").ToLocalChecked(), Nan::New<String>(zlibVersion()).ToLocalChecked(), static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete));
 }
 
-NODE_MODULE_INIT() {
-    AllInit(exports);
-}
+NAN_MODULE_WORKER_ENABLED(zlib_sync, AllInit)


### PR DESCRIPTION
This allows support for using zlib-sync in worker threads

While I gave it a small test (and seems to work perfectly fine), I don't have guarantees that something won't break. However, I don't see the context being used anywhere soo..should be good!