### PR TITLE
Bump nan from 2.17.0 to 2.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "homepage": "https://github.com/abalabahaha/zlib-sync#readme",
     "dependencies": {
-        "nan": "^2.17.0"
+        "nan": "^2.18.0"
     },
     "devDependencies": {
         "@types/node": "^12.11.7",


### PR DESCRIPTION
Fixes:
```
/root/.cache/node-gyp/21.0.0/include/node/v8-local-handle.h: In instantiation of ‘v8::Local<T>::Local(v8::Local<S>) [with S =
../../nan/nan_callbacks_12_inl.h:175:53:   required from here
/root/.cache/node-gyp/21.0.0/include/node/v8-local-handle.h:253:42: error: static assertion failed: type check
  253 |     static_assert(std::is_base_of<T, S>::value, "type check");
      |                                          ^~~~~
make: *** [zlib_sync.target.mk:122: Release/obj.target/zlib_sync/src/zlib_sync.o] Error 1
make: Leaving directory '/home/jam/discordbot/node_modules/zlib-sync/build'
gyp ERR! build error$
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/home/jam/discordbot/node_modules/node-gyp/lib/build.js:203:23)
gyp ERR! stack     at ChildProcess.emit (node:events:515:28)
gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:294:12)
gyp ERR! System Linux 5.4.0-153-generic
gyp ERR! command "/root/.nvm/versions/node/v21.0.0/bin/node" "/home/jam/discordbot/node_modules/node-gyp/bin/node-gyp.js" "re
gyp ERR! cwd /home/jam/discordbot/node_modules/zlib-sync
gyp ERR! node -v v21.0.0
gyp ERR! node-gyp -v v9.4.0
gyp ERR! not ok$
```

Similar issue to #9 after NodeJS 21 v8 Upgrade