### PR TITLE
chore: bump nan from 2.18.0 to 2.22.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "homepage": "https://github.com/abalabahaha/zlib-sync#readme",
     "dependencies": {
-        "nan": "^2.18.0"
+        "nan": "^2.22.2"
     },
     "devDependencies": {
         "@types/node": "^12.11.7",


### PR DESCRIPTION
This is enough to unlock building up to Node.js v24, plus or minus a ton of deprecation warnings.